### PR TITLE
Fixed README PowerShell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are using Windows, the command provided in the instructions will not work
 
 **PowerShell Terminal Command:**
 ```powershell
-docker run -it -p 3000:3000 ${PWD}:/github/workspace ghcr.io/bcgov/devhub-techdocs-publish preview
+docker run -it -p 3000:3000 -v ${PWD}:/github/workspace ghcr.io/bcgov/devhub-techdocs-publish preview
 ```
 
 **WSL Terminal Command:**


### PR DESCRIPTION
This pull request includes a small but important change to the `README.md` file. The change corrects the PowerShell terminal command for running the Docker container by adding the `-v` option to properly mount the current directory.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27): Updated the PowerShell terminal command to include the `-v` option for volume mounting.