### PR TITLE
Self-Hosted CICD Runners Guidance

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -6,7 +6,7 @@ on:
         branches: [ dev ]
         paths:
             - "mkdocs.yml"
-            - "docs/*"
+            - "docs/**"
 
 jobs:
     test_techdocs_build_job:

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -6,7 +6,7 @@ on:
         branches: [ main ]
         paths:
             - "mkdocs.yml"
-            - "docs/*"
+            - "docs/**"
 
 jobs:
     test_techdocs_build_job:

--- a/docs/azure/best-practices/ci-cd.md
+++ b/docs/azure/best-practices/ci-cd.md
@@ -6,11 +6,11 @@ Last updated: **{{ git_revision_date_localized }}**
 
 If you are using GitHub Actions for your CI/CD pipeline, consider the following best practices:
 
-* Use [OpenID Connect (OIDC) authentication](#configuring-github-action-oidc-authentication-to-azure) for GitHub Actions to authenticate with Azure.
-
-* [Self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) on Azure are required to access data storage and database services from GitHub Actions. Public access to these services is not supported.
+* Configure [OpenID Connect (OIDC) authentication](#configuring-github-action-oidc-authentication-to-azure) for GitHub Actions to authenticate with Azure.
 
 * If using [Terraform](https://www.terraform.io/), be aware of the limitations when [creating Subnets](../best-practices/be-mindful.md#using-terraform-to-create-subnets), and the use of the [AzAPI Terraform Provider](be-mindful.md#azapi-terraform-provider-using-azapi_update_resource).
+
+* [Self-hosted runners](#self-hosted-runners-on-azure) on Azure are required to access data storage and database services from GitHub Actions. Public access to these services is not supported.
 
 ### Configuring GitHub Action OIDC Authentication to Azure
 
@@ -23,8 +23,8 @@ Here's a quick summary on how to set it up:
 1. The GitHub Identity Provider has already been configured in the Azure subscriptions in your Project Set
 2. In your Azure subscription:
 
-  - Create an Entra ID application and a service principal
-  - Add federated credentials for the Entra ID application
+  - Create an Entra ID Application and a Service Principal
+  - Add federated credentials for the Entra ID Application
   - Create GitHub secrets for storing Azure configuration
 
 3. In your GitHub workflows:
@@ -33,3 +33,20 @@ Here's a quick summary on how to set it up:
   - Use the [azure/login](https://github.com/Azure/login) action to exchange the OIDC token (JWT) for a cloud access token
 
 This allows GitHub Actions to authenticate to Azure and access resources.
+
+### Self-Hosted Runners on Azure
+
+Microsoft has created an [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners). The Public Cloud team has tested this module, and verified that it works within our Azure environment (with a few customizations).
+
+We have created a dedicated/centralized GitHub repository to provide sample Terraform code for creating various application patterns, and various tools. This repository is called [Azure Landing Zone Samples (azure-lz-samples)](https://github.com/bcgov/azure-lz-samples).
+
+You can find the sample Terraform code for deploying self-hosted GitHub runners in the `/tools/cicd_self_hosted_agents/` directory.
+
+!!! info "Pre-requisites"
+    Please take special note of the pre-requisites listed in the README file in the `/tools/cicd_self_hosted_agents/` directory. It describes the necessary subnets that the self-hosted runners need to be deployed in.
+
+!!! question "Cross-Subscription Access"
+    If you plan to deploy the self-hosted runners into a different Azure subscription than where your resources will be deployed (ie. in your **Tools** subscription), you will need to [submit a firewall request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team. This request will allow the self-hosted runners to access the necessary resources in the other subscription.
+
+!!! note ""
+   When using the [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) (or any other modules), Terraform may show that it will remove certain tags from resources. This is because the module is not aware of the tags that are set on the resources. If you want to keep the tags, you can add a `lifecycle` block with the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) feature, to the resource in your Terraform code to ignore the tags.


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows and the Azure CI/CD best practices documentation. The most important changes include expanding the file path patterns in the workflow triggers and reorganizing and enhancing the best practices documentation for better clarity and completeness.

### Workflow Trigger Updates:

* [`.github/workflows/publish-dev.yaml`](diffhunk://#diff-2316a3ea934daa60f0d81bd6cc59e1df7db4b6e6034d53070457c1e3e14f085bL9-R9): Updated the file path pattern from `"docs/*"` to `"docs/**"` to include all nested files and directories.
* [`.github/workflows/publish-prod.yaml`](diffhunk://#diff-d04cf538d43d1c3cf17f57bc834729e7b3a72dc98bf812ff7af42eddbeb6a18eL9-R9): Updated the file path pattern from `"docs/*"` to `"docs/**"` to include all nested files and directories.

### Documentation Enhancements:

* [`docs/azure/best-practices/ci-cd.md`](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L9-R14): Reorganized the best practices section for using GitHub Actions with Azure, including moving the self-hosted runners recommendation to a more appropriate location.
* [`docs/azure/best-practices/ci-cd.md`](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L26-R27): Capitalized "Application" and "Service Principal" for consistency in the setup instructions.
* [`docs/azure/best-practices/ci-cd.md`](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6R36-R52): Added a detailed section on self-hosted runners on Azure, including information on the Azure Verified Module, sample Terraform code, and pre-requisites.