### PR TITLE
Removed content about resource locks

### DIFF
--- a/docs/azure/best-practices/be-mindful.md
+++ b/docs/azure/best-practices/be-mindful.md
@@ -78,30 +78,6 @@ If you are using the [AzAPI Terraform Provider](https://learn.microsoft.com/en-u
 
 This means, changes to the `azapi_update_resource` resource may _appear_ to apply changes (ie. remove properties/configurations previous added according to the `terraform plan` output), but this doesn't actually apply those changes in Azure.
 
-<!-- TODO: Remove this section once Resource Locks have been removed -->
-## Working with resource locks
-
-As part of our security and governance measures, resource locks are automatically applied to critical infrastructure components, particularly networking resources like Virtual Networks (VNets). While these locks provide an important safeguard against accidental deletion, they can sometimes interfere with legitimate resource management tasks.
-
-### Deleting resources protected by locks
-
-If you encounter issues when trying to delete a resource you've created (such as a VM) due to a lock on the parent resource (like a VNet), follow these steps:
-
-1. **Identify the lock**: Locate the resource lock on the parent resource (usually the VNet).
-
-2. **Remove the lock**: You have permissions to remove these locks when necessary. To do so:
-   - Navigate to the VNet in the Azure portal
-   - Go to the "Locks" section
-   - Delete the lock that's preventing the operation
-
-3. **Perform your operation**: Once the lock is removed, you should be able to delete your resource as needed.
-
-4. **Be aware of automation**: Our automation systems will periodically reapply these locks to ensure ongoing protection. If you need the lock to remain off for an extended period, please contact the Public Cloud team.
-
-5. **Best practice**: After completing your task, if the automation hasn't yet reapplied the lock, consider manually reapplying it to maintain security.
-
-Remember, these locks are in place for good reason. Always double-check that you're deleting the correct resources and understand the implications before removing any locks.
-
 ## Azure Control-Plane vs Data-Plane access differences
 
 When working with Azure services, it's important to understand the differences between [control-plane](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/control-plane-and-data-plane#control-plane) and [data-plane](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/control-plane-and-data-plane#data-plane) access. The control plane is used to manage resources, while the data plane is used to interact with the resources themselves.

--- a/docs/azure/design-build-deploy/networking.md
+++ b/docs/azure/design-build-deploy/networking.md
@@ -43,16 +43,3 @@ Advanced features are implemented and configured including:
 For more complex applications, an [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/overview) is the preferred method for exposing your application to the Internet. It provides a web traffic (OSI layer 7) load balancer that enables you to manage traffic to your web applications.
 
 To adhere to security best practices, the Application Gateway should also be configured with a [Web Application Firewall (WAF)](https://learn.microsoft.com/en-us/azure/application-gateway/features#web-application-firewall) to protect your applications from common exploits and vulnerabilities.
-
-<!-- TODO: Remove this section once Resource Locks have been removed -->
-## Resource locks on networking components
-
-To maintain the integrity and stability of the networking infrastructure, [resource locks](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json) are automatically applied to key networking components, including Virtual Networks (VNets). These locks prevent accidental deletion of critical resources.
-
-**Important:** If you need to delete a resource that you've created within the VNet (such as a VM), you may encounter issues due to these locks. In such cases:
-
-* You can temporarily remove the lock to perform the necessary operation
-* You have the permissions to remove these locks when needed
-* Be aware that our automation will re-apply the locks periodically to ensure ongoing protection
-
-For more detailed guidance on working with resource locks, please refer to the [Be Mindful](../best-practices/be-mindful.md#working-with-resource-locks) documentation.


### PR DESCRIPTION
This pull request includes changes to the Azure documentation to remove outdated sections related to resource locks. The most important changes include the removal of guidance on working with resource locks from two documentation files.

Documentation updates:

* [`docs/azure/best-practices/be-mindful.md`](diffhunk://#diff-10147fa17f649ce4a7c7164f711a9677a0270898ad7c6fd0367b4f83ec0f4130L81-L104): Removed the section on working with resource locks, including steps for deleting resources protected by locks and best practices for handling locks.
* [`docs/azure/design-build-deploy/networking.md`](diffhunk://#diff-f35a06a25a7c8d2c9dae64ec255a59e2f87659d88d2755e95a38cc85ddf61616L46-L58): Removed the section on resource locks on networking components, including information on how to handle locks when deleting resources within a Virtual Network (VNet).