### PR TITLE
Added guidance for API Management, and VNET CIDRs

### DIFF
--- a/docs/azure/best-practices/be-mindful.md
+++ b/docs/azure/best-practices/be-mindful.md
@@ -87,3 +87,11 @@ Even though someone may have **Owner-level** permissions on a resource, they may
 For example, some Azure services and solution patterns may require additional data-level permissions, such as [Storage Blob Data Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-reader), [Search Index Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/ai-machine-learning#search-index-data-contributor), etc.
 
 For a list of built-in roles and their permissions, refer to the [Azure built-in roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles) documentation.
+
+## API Management Service
+
+The current version (v1) of the Azure [API Management Service](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) does not support [inbound Private Endpoints](https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts#inbound-private-endpoint). This means that a DNS record must be created to access the service from within a Virtual Network. This is not automated (like other [private endpoints](#private-endpoints-and-dns) are in the Landing Zones).
+
+If you are using v1 of the API Management Service, please [submit a Service Request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team to have the DNS record created for you.
+
+Version 2 of the API Management Service is [not yet supported](https://learn.microsoft.com/en-us/azure/api-management/api-management-region-availability#supported-regions-for-v2-tiers-and-workspace-gateways) in the Canada Azure regions. Once it is available, it is recommended to use this version, as it will support Private Endpoints.

--- a/docs/azure/design-build-deploy/networking.md
+++ b/docs/azure/design-build-deploy/networking.md
@@ -8,6 +8,9 @@ The following sections describe the networking components within the Azure Landi
 
 Within each Project Set deployed in the Azure Landing Zone, a [Virtual Network (VNet)](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview) is created to provide network isolation and security for the resources deployed within it. This VNet is the foundation for all network connectivity within the Azure Landing Zone.
 
+!!! danger "VNet CIDR Changes"
+    The CIDR range for the VNet is defined at the time of deployment, and cannot be changed after deployment. By default, each Project Set is provided with a `/24` CIDR range. If you require a change to the  CIDR range, please [submit a Service Request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team.
+
 This VNet is connected with the central hub (vWAN), and receives default routes to direct all traffic (ie. Internet and private) through the firewall located in the central hub.
 
 There are no subnets that are pre-created within the VNet. Each team is responsible for creating their own subnets based on their requirements. Subnets should be created within the VNet to segment resources based on their function or security requirements.


### PR DESCRIPTION
This pull request includes updates to the Azure best practices documentation, specifically regarding API Management Service and Virtual Network (VNet) CIDR changes. The most important changes include adding information about the current and future versions of the API Management Service and highlighting the immutability of VNet CIDR ranges after deployment.

Updates to Azure best practices documentation:

* [`docs/azure/best-practices/be-mindful.md`](diffhunk://#diff-10147fa17f649ce4a7c7164f711a9677a0270898ad7c6fd0367b4f83ec0f4130R90-R97): Added a new section about the Azure API Management Service, detailing the limitations of the current version (v1) regarding inbound Private Endpoints and the recommendation to use version 2 once it becomes available.

* [`docs/azure/design-build-deploy/networking.md`](diffhunk://#diff-f35a06a25a7c8d2c9dae64ec255a59e2f87659d88d2755e95a38cc85ddf61616R11-R13): Added a warning about the immutability of the VNet CIDR range after deployment, advising users to submit a Service Request if changes are needed.