### PR TITLE
Added content for Managed DevOps Pools

### DIFF
--- a/docs/azure/best-practices/ci-cd.md
+++ b/docs/azure/best-practices/ci-cd.md
@@ -10,7 +10,7 @@ If you are using GitHub Actions for your CI/CD pipeline, consider the following 
 
 * If using [Terraform](https://www.terraform.io/), be aware of the limitations when [creating Subnets](../best-practices/be-mindful.md#using-terraform-to-create-subnets), and the use of the [AzAPI Terraform Provider](be-mindful.md#azapi-terraform-provider-using-azapi_update_resource).
 
-* [Self-hosted runners](#self-hosted-runners-on-azure) on Azure are required to access data storage and database services from GitHub Actions. Public access to these services is not supported.
+* [Self-hosted runners](#github-self-hosted-runners-on-azure) on Azure are required to access data storage and database services from GitHub Actions. Public access to these services is not supported.
 
 ### Configuring GitHub Action OIDC Authentication to Azure
 

--- a/docs/azure/best-practices/ci-cd.md
+++ b/docs/azure/best-practices/ci-cd.md
@@ -34,7 +34,7 @@ Here's a quick summary on how to set it up:
 
 This allows GitHub Actions to authenticate to Azure and access resources.
 
-### Self-Hosted Runners on Azure
+### GitHub Self-Hosted Runners on Azure
 
 Microsoft has created an [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners). The Public Cloud team has tested this module, and verified that it works within our Azure environment (with a few customizations).
 
@@ -48,5 +48,28 @@ You can find the sample Terraform code for deploying self-hosted GitHub runners 
 !!! question "Cross-Subscription Access"
     If you plan to deploy the self-hosted runners into a different Azure subscription than where your resources will be deployed (ie. in your **Tools** subscription), you will need to [submit a firewall request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team. This request should state that you need to allow the self-hosted runners to access resources in another subscription.
 
-!!! note ""
-   When using the [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) (or any other modules), Terraform may show that it will remove certain tags from resources. This is because the module is not aware of the tags that are set on the resources. If you want to keep the tags, you can add a `lifecycle` block with the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) feature, to the resource in your Terraform code to ignore the tags.
+!!! note "Terraform and resource tags"
+    When using the [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) (or any other modules), Terraform may show that it will remove certain tags from resources. This is because the module is not aware of the tags that are set on the resources. If you want to keep the tags, you can add a `lifecycle` block with the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) feature, to the resource in your Terraform code to ignore the tags.
+
+## Azure Pipelines
+
+If you are using Azure Pipelines for your CI/CD pipeline, consider the following best practices:
+
+* Configure [Azure DevOps Workload identity federation (OIDC) with Terraform](https://devblogs.microsoft.com/devops/introduction-to-azure-devops-workload-identity-federation-oidc-with-terraform/) for Azure Pipelines to authenticate with Azure.
+
+### Managed DevOps Pools on Azure
+
+Microsoft has created an [Azure Verified Module for Managed DevOps Pools](https://github.com/Azure/terraform-azurerm-avm-res-devopsinfrastructure-pool). The Public Cloud team has tested this module, and verified that it works within our Azure environment.
+
+We have created a dedicated/centralized GitHub repository to provide sample Terraform code for creating various application patterns, and various tools. This repository is called [Azure Landing Zone Samples (azure-lz-samples)](https://github.com/bcgov/azure-lz-samples).
+
+You can find the sample Terraform code for deploying DevOps Managed Pools in the `/tools/cicd_managed_devops_pools/` directory.
+
+!!! info "Pre-requisites"
+    Please take special note of the pre-requisites listed in the README file in the `/tools/cicd_managed_devops_pools/` directory. It describes the necessary resources, and Resource Providers that are required.
+
+!!! question "Cross-Subscription Access"
+    If you plan to deploy the Managed DevOps Pool into a different Azure subscription than where your resources will be deployed (ie. in your **Tools** subscription), you will need to [submit a firewall request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team. This request should state that you need to allow the Managed DevOps Pool to access resources in another subscription.
+
+!!! note "Terraform and resource tags"
+    When using the [Azure Verified Module for Managed DevOps Pools](https://github.com/Azure/terraform-azurerm-avm-res-devopsinfrastructure-pool) (or any other modules), Terraform may show that it will remove certain tags from resources. This is because the module is not aware of the tags that are set on the resources. If you want to keep the tags, you can add a `lifecycle` block with the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) feature, to the resource in your Terraform code to ignore the tags.


### PR DESCRIPTION
This pull request includes updates to the CI/CD best practices documentation for Azure, specifically adding new sections and refining existing ones. The changes primarily focus on improving the guidance for using self-hosted runners and managed DevOps pools on Azure.

Documentation updates:

* [`docs/azure/best-practices/ci-cd.md`](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L37-R37): Changed the section title from "Self-Hosted Runners on Azure" to "GitHub Self-Hosted Runners on Azure" for clarity.
* [`docs/azure/best-practices/ci-cd.md`](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L51-R75): Added a new section for "Azure Pipelines" with best practices for configuring Azure DevOps Workload identity federation (OIDC) and using the Azure Verified Module for Managed DevOps Pools. This includes links to sample Terraform code and pre-requisites for deploying DevOps Managed Pools.