### PR TITLE
Added content for Managed DevOps Pools

### DIFF
--- a/docs/azure/best-practices/ci-cd.md
+++ b/docs/azure/best-practices/ci-cd.md
@@ -45,13 +45,13 @@ You can find the sample Terraform code for deploying self-hosted GitHub runners 
 !!! info "Pre-requisites"
     Please take special note of the pre-requisites listed in the README file in the `/tools/cicd_self_hosted_agents/` directory. It describes the necessary subnets that the self-hosted runners need to be deployed in.
 
-!!! question "Cross-Subscription Access"
+!!! question "Planning to use across subscriptions?"
     If you plan to deploy the self-hosted runners into a different Azure subscription than where your resources will be deployed (ie. in your **Tools** subscription), you will need to [submit a firewall request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team. This request should state that you need to allow the self-hosted runners to access resources in another subscription.
 
 !!! note "Terraform and resource tags"
     When using the [Azure Verified Module (AVM) for CICD Agents and Runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) (or any other modules), Terraform may show that it will remove certain tags from resources. This is because the module is not aware of the tags that are set on the resources. If you want to keep the tags, you can add a `lifecycle` block with the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) feature, to the resource in your Terraform code to ignore the tags.
 
-## Azure Pipelines
+## Azure pipelines
 
 If you are using Azure Pipelines for your CI/CD pipeline, consider the following best practices:
 
@@ -68,7 +68,7 @@ You can find the sample Terraform code for deploying DevOps Managed Pools in the
 !!! info "Pre-requisites"
     Please take special note of the pre-requisites listed in the README file in the `/tools/cicd_managed_devops_pools/` directory. It describes the necessary resources, and Resource Providers that are required.
 
-!!! question "Cross-Subscription Access"
+!!! question "Planning to use across subscriptions?"
     If you plan to deploy the Managed DevOps Pool into a different Azure subscription than where your resources will be deployed (ie. in your **Tools** subscription), you will need to [submit a firewall request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team. This request should state that you need to allow the Managed DevOps Pool to access resources in another subscription.
 
 !!! note "Terraform and resource tags"


### PR DESCRIPTION
This pull request includes updates to the CI/CD best practices documentation for Azure. The changes focus on clarifying the use of self-hosted runners and introducing best practices for Azure Pipelines.

Updates to CI/CD best practices:

* Updated references to self-hosted runners on Azure to use the term "GitHub Self-Hosted Runners" for clarity. [[1]](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L13-R13) [[2]](diffhunk://#diff-a8ef159b74b03b56991931505a77d29371cfee1fd720bc3a0a4c4c2a849520b6L37-R37)
* Added a new section for Azure Pipelines, including best practices for configuring Azure DevOps Workload identity federation (OIDC) and using the Azure Verified Module for Managed DevOps Pools.