### PR TITLE
Link fixes

### DIFF
--- a/docs/azure/best-practices/azure-services.md
+++ b/docs/azure/best-practices/azure-services.md
@@ -17,7 +17,7 @@ To follow best practices when using Azure App Services with VNet integration, if
 
 ### API Management service
 
-The current version (v1) of the Azure [API Management Service](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) doesn't work with [inbound Private Endpoints](https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts#inbound-private-endpoint). To access the service from within a virtual network, you must create a DNS record. Unlike other [private endpoints](#private-endpoints-and-dns) in the Landing Zones, this process isn't automated.
+The current version (v1) of the Azure [API Management Service](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) doesn't work with [inbound Private Endpoints](https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts#inbound-private-endpoint). To access the service from within a virtual network, you must create a DNS record. Unlike other [private endpoints](./be-mindful.md#private-endpoints-and-dns) in the Landing Zones, this process isn't automated.
 
 If you are using v1 of the API Management Service, please [submit a Service Request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team to have the DNS record created for you.
 

--- a/docs/azure/best-practices/iac-and-ci-cd.md
+++ b/docs/azure/best-practices/iac-and-ci-cd.md
@@ -63,7 +63,7 @@ If you are using GitHub Actions for your CI/CD pipeline, consider the following 
 
 - Configure [OpenID Connect (OIDC) authentication](#configuring-github-action-oidc-authentication-to-azure) for GitHub Actions to authenticate with Azure.
 
-- If using [Terraform](https://www.terraform.io/), be aware of the limitations when [creating Subnets](../best-practices/be-mindful.md#using-terraform-to-create-subnets), and the use of the [AzAPI Terraform Provider](be-mindful.md#azapi-terraform-provider-using-azapi_update_resource).
+- If using [Terraform](https://www.terraform.io/), be aware of the limitations when [creating Subnets](#using-terraform-to-create-subnets), and the use of the [AzAPI Terraform Provider](#azapi-terraform-provider-using-azapi_update_resource).
 
 - [Self-hosted runners](#github-self-hosted-runners-on-azure) on Azure are required to access data storage and database services from GitHub Actions. Public access to these services is not supported.
 


### PR DESCRIPTION
This pull request includes updates to documentation to correct and improve internal link references. The changes ensure that the links correctly point to the intended sections within the same or other documents.

Documentation updates:

* [`docs/azure/best-practices/azure-services.md`](diffhunk://#diff-1c625cb8528aa84910b36fdc4c6438fb12131055f4bab40b7f9f90d7cf38d7cbL20-R20): Updated the link for private endpoints to point to the correct section within the same document.
* [`docs/azure/best-practices/iac-and-ci-cd.md`](diffhunk://#diff-f0d07ede0c302f925294260175c928493d6644124fbe0d3dafcc1f7513b1a36eL66-R66): Corrected the internal links for Terraform limitations and AzAPI Terraform Provider to point to the appropriate sections within the same document.