### PR TITLE
Added links to RocketChat channels

### DIFF
--- a/docs/welcome/support.md
+++ b/docs/welcome/support.md
@@ -34,6 +34,9 @@ There are multiple ways to get support for the Public cloud Platform, including:
 
 - [Jira Service Management (JSM)](https://citz-do.atlassian.net/servicedesk/customer/portal/3) (preferred method)
 - [Rocket.Chat](https://chat.developer.gov.bc.ca/)
+  - Channel: [public-cloud-support](https://chat.developer.gov.bc.ca/channel/public-cloud-general)
+  - Channel: [public-cloud-how-to](https://chat.developer.gov.bc.ca/channel/public-cloud-how-to)
+  - Channel: [public-cloud-alerts](https://chat.developer.gov.bc.ca/channel/public-cloud-alerts)
 
 ## Cloud vendor support
 


### PR DESCRIPTION
This pull request updates the support documentation for the Public Cloud Platform by adding new Rocket.Chat channels to provide more specific support options.

Documentation updates:

* [`docs/welcome/support.md`](diffhunk://#diff-b5aece035344bfe20ff1acca1dd6f64f355c639dcb20e69cdeb279e5190ad7b2R37-R39): Added three new Rocket.Chat channels: `public-cloud-support`, `public-cloud-how-to`, and `public-cloud-alerts`, to enhance the support options available for the Public Cloud Platform.