### PR TITLE
Update publish workflows

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -16,6 +16,8 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
             -   name: Build TechDocs
                 uses: bcgov/devhub-techdocs-publish@stable
                 id: build_and_publish

--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -16,6 +16,8 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
             -   name: Build TechDocs
                 uses: bcgov/devhub-techdocs-publish@stable
                 id: build_and_publish


### PR DESCRIPTION
The `git-revision-date-localized` plugin used in the [mkdocs.yml](https://github.com/bcgov/public-cloud-techdocs/blob/69a26247594613adbd074297d851fe101f1a1c24/mkdocs.yml#L60) file requires [that fetch-depth be set to 0](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin?tab=readme-ov-file#note-when-using-build-systems-like-github-actions) in order to function correctly. 

