### PR TITLE
Updated AzAPI code example 

### DIFF
--- a/docs/azure/best-practices/iac-and-ci-cd.md
+++ b/docs/azure/best-practices/iac-and-ci-cd.md
@@ -27,7 +27,7 @@ Therefore, instead of using the `azurerm_subnet` resource to create subnets, you
 
 ```terraform
 resource "azapi_resource" "subnets" {
-  type = "Microsoft.Network/virtualNetworks/subnets@2023-04-01"
+  type = "Microsoft.Network/virtualNetworks/subnets@2024-05-01"
 
   name      = "SubnetName"
   parent_id = data.azurerm_virtual_network.vnet.id
@@ -37,13 +37,14 @@ resource "azapi_resource" "subnets" {
     data.azurerm_virtual_network.vnet.id
   ]
 
-  body = jsonencode({
+  # It's not necessary to use the `jsonencode` function to encode the HCL object to JSON, just use the HCL object directly
+  body = {
     properties = {
       networkSecurityGroup = {
         id = azurerm_network_security_group.id
       }
     }
-  })
+  }
 
   response_export_values = ["*"]
 }


### PR DESCRIPTION
This pull request updates the Azure Infrastructure as Code (IaC) best practices documentation to reflect changes in the `azapi_resource` usage for creating subnets. The changes include updating the API version and simplifying the encoding of the `body` property.

### Updates to Azure IaC best practices:

* **Updated API version for `azapi_resource` subnets**: Changed the `type` property to use `Microsoft.Network/virtualNetworks/subnets@2024-05-01` instead of the older `2023-04-01` version.
* **Simplified `body` property usage**: Removed the use of `jsonencode` for encoding the `body` property and replaced it with a direct HCL object. This simplifies the code and improves readability.