### PR TITLE
Added OpenShift connectivity guidance

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,3 +7,4 @@ IgnoreURLs:
   - "https://loginproxy.gov.bc.ca"
   - "https://login.nimbus.cloud.gov.bc.ca/"
   - "https://ssbc-client.gov.bc.ca/"
+  - "https://digital.gov.bc.ca/"

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,3 +8,4 @@ IgnoreURLs:
   - "https://login.nimbus.cloud.gov.bc.ca/"
   - "https://ssbc-client.gov.bc.ca/"
   - "https://digital.gov.bc.ca/"
+  - "https://hungryboysl.wordpress.com"

--- a/docs/azure/design-build-deploy/networking-express-route.md
+++ b/docs/azure/design-build-deploy/networking-express-route.md
@@ -51,7 +51,7 @@ For example: `MCCS_CITZ_ALZ_LIVE_abc123_prod`.
 
 ## OpenShift connectivity
 
-If you are using OpenShift, and want to connect to it from Azure, you will need to submit an [on-premises firewall request form](https://ssbc-client.gov.bc.ca/services/3rdpartygateway/order.htm). However, for the Source or Destination fields, use the appropriate Objects respective of the OpenShift cluster you are connecting to.
+If you are using OpenShift, and want to connect to it from Azure, you will need to submit an [on-premises firewall request form](https://ssbc-client.gov.bc.ca/services/3rdpartygateway/order.htm). However, for the Source or Destination fields, use the appropriate Objects for the OpenShift cluster you are connecting to.
 
 !!! note "OpenShift firewall objects"
     For specific details on the appropriate OpenShift firewall objects to use, please refer to the [OpenShift documentation](https://digital.gov.bc.ca/technology/cloud/private/internal-resources/topology/).

--- a/docs/azure/design-build-deploy/networking-express-route.md
+++ b/docs/azure/design-build-deploy/networking-express-route.md
@@ -48,3 +48,10 @@ For example: `MCCS_CITZ_ALZ_LIVE_abc123_prod`.
 
 !!! warning "Bi-directional traffic"
     If you need bi-directional traffic, for example on-premises to Azure, add another rule in the Traffic Table for that flow.
+
+## OpenShift connectivity
+
+If you are using OpenShift, and want to connect to it from Azure, you will need to submit an [on-premises firewall request form](https://ssbc-client.gov.bc.ca/services/3rdpartygateway/order.htm). However, for the Source or Destination fields, use the appropriate Objects respective of the OpenShift cluster you are connecting to.
+
+!!! note "OpenShift firewall objects"
+    For specific details on the appropriate OpenShift firewall objects to use, please refer to the [OpenShift documentation](https://digital.gov.bc.ca/technology/cloud/private/internal-resources/topology/).


### PR DESCRIPTION
This pull request updates documentation and configuration to improve support for OpenShift connectivity and maintain accurate link validation. The main changes include adding guidance for connecting Azure to OpenShift and updating link ignore rules for documentation validation.

Documentation improvements:

* Added a new section to `docs/azure/design-build-deploy/networking-express-route.md` explaining how to connect Azure to OpenShift, including instructions for submitting an on-premises firewall request form and specifying the correct firewall objects.
* Included a note in the same documentation file that links to the relevant OpenShift firewall objects in the OpenShift documentation.

Configuration update:

* Updated the `.htmltest.yml` configuration to ignore the `https://digital.gov.bc.ca/` URL during documentation link validation.