### PR TITLE
docs: clarify group ownership requirements for Technical Leads

### DIFF
--- a/docs/azure/design-build-deploy/user-management.md
+++ b/docs/azure/design-build-deploy/user-management.md
@@ -54,7 +54,7 @@ These groups are assigned roles at the Management Group level, which automatical
 ### As a Product Owner or Technical Lead with the Owner role, you can:
 
 !!! note
-    Technical Leads must first be added as group owners by the Product Owner before they can manage group memberships. By default, only Product Owners have the ability to manage security group memberships.
+    To manage group memberships, users (including Technical Leads) must be added as group owners by the Product Owner. By default, only Product Owners have the ability to manage security group memberships. The Product Owner can delegate this ability to any user by making them a group owner.
 
 - Manage membership in your security groups (`DO_PuC_Azure_Live_{LicensePlate}_{Role}`) to grant Owner, Contributor, or Reader access across the Project Set (requires group owner permissions)
 - Create custom roles for specific needs.


### PR DESCRIPTION
This PR updates the user management documentation to clarify that Technical Leads must be added as group owners by Product Owners before they can manage group memberships.

Changes made:
- Added a note explaining that Technical Leads need to be added as group owners by Product Owners
- Clarified that managing group memberships requires group owner permissions

Fixes feedback received about the documentation implying that Technical Leads with the Owner role can manage group memberships by default.

resolves #119 