### PR TITLE
APIM guidance update

### DIFF
--- a/docs/azure/azure-services/api-management.md
+++ b/docs/azure/azure-services/api-management.md
@@ -2,8 +2,9 @@
 
 Last updated: **{{ git_revision_date_localized }}**
 
-The current version (v1) of the Azure [API Management Service](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) doesn't work with [inbound Private Endpoints](https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts#inbound-private-endpoint). To access the service from within a virtual network, you must create a DNS record. Unlike other [private endpoints](../best-practices/be-mindful.md#private-endpoints-and-dns) in the Landing Zones, this process isn't automated.
+Version 1 of the Azure [API Management Service](https://learn.microsoft.com/en-us/azure/api-management/api-management-key-concepts) doesn't work with [inbound private endpoints](https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts#inbound-private-endpoint). To access the service from within a virtual network, you must create a DNS record. Unlike other [private endpoints](../best-practices/be-mindful.md#private-endpoints-and-dns) in the Landing Zones, this process isn't automated.
 
 If you are using v1 of the API Management Service, please [submit a Service Request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public cloud team to have the DNS record created for you.
 
-Version 2 of the API Management Service [isn't currently available](https://learn.microsoft.com/en-us/azure/api-management/api-management-region-availability#supported-regions-for-v2-tiers-and-workspace-gateways) in the Canada Azure regions. When available, use this version, as it'll support Private Endpoints.
+!!! success "APIM v2"
+    Version 2 of the API Management Service is now available in the Canada Central Azure region. Please use the [v2 tiers](https://learn.microsoft.com/en-us/azure/api-management/v2-service-tiers-overview) of APIM to support network isolation and private endpoints.


### PR DESCRIPTION
This pull request updates the Azure API Management documentation to reflect the availability of APIM v2 in Canada Central and provides clearer guidance on using private endpoints and network isolation.

Documentation updates for Azure API Management:

* Clarified that APIM v2 is now available in the Canada Central region and recommends using v2 tiers for network isolation and private endpoints, replacing previous language stating it was unavailable.
* Improved formatting and language in the section describing differences between v1 and v2, including a new callout box for APIM v2 availability.