### PR TITLE
Added KeyVault secret validity requirement

### DIFF
--- a/docs/azure/get-started-with-azure/guardrails.md
+++ b/docs/azure/get-started-with-azure/guardrails.md
@@ -113,7 +113,7 @@ For many services, data *must* be encrypted at rest using Customer-Managed Keys 
   * Expired keys must be deleted
 * **Secrets:**
   * Must have expiration date
-  * Cannot be active longer than specified days
+  * Cannot be active longer than specified days (default 90 days)
   * Must have content type set
   * Policies audit if close to expiration
 * **Certificates:**


### PR DESCRIPTION
This pull request makes a minor clarification to the Azure guardrails documentation regarding secret expiration policies. The change specifies the default maximum active period for secrets.

- Documentation update: Clarified that secrets "cannot be active longer than specified days" now explicitly states the default is 90 days.