### PR TITLE
Updated AKS Guidance with CIDR Ranges

### DIFF
--- a/docs/azure/azure-services/aks.md
+++ b/docs/azure/azure-services/aks.md
@@ -2,24 +2,34 @@
 
 Last updated: **{{ git_revision_date_localized }}**
 
-When deploying AKS clusters, it is critical to ensure that the **service and pod CIDR ranges do not overlap** with any other networks that cluster pods will need to communicate with. Overlapping address spaces can cause connectivity issues between your AKS workloads and other resources, both within Azure and on-premises.
+AKS networking and security choices affect cluster reliability. Use this page to plan CIDR ranges, DNS, and core security settings.
+
+---
+
+## Networking
+
+When you deploy AKS clusters, keep service and pod CIDR ranges unique. Do not overlap them with connected networks. Overlap can break connectivity between AKS workloads, Azure resources, and on-premises systems.
 
 !!! warning "Important notes about AKS networking"
-    - **Virtual Networks (VNets) are pre-created** by the Public cloud team. You cannot create new VNets, but you can create subnets within the existing VNet for your AKS resources
-    - Plan your subnet, pod, and service address ranges carefully to avoid conflicts and to allow for future scaling
-    - **Reserved address space**: The `10.10.0.0/16` range is reserved for AKS deployments. However, this same range may also be used for extended non-routable peered VNets if teams require additional IP addresses beyond what's provided in the standard routable VNet
-    - **Future network expansion**: If you anticipate needing an extended network in the future, it's important to plan your AKS CIDR ranges accordingly to avoid conflicts. Contact the Public Cloud team early in your planning process for guidance on optimal address allocation
+    - **Public Cloud team creates VNets**: Use the existing VNets for AKS. Create subnets in those VNets for AKS resources.
+    - **Plan address ranges early**: Choose subnet, pod, and service ranges that avoid conflicts and support growth.
+    - **Reserved pod CIDR ranges**: `10.10.0.0/18` and `10.10.128.0/18` are reserved for AKS pod CIDRs. Each block provides about 16,384 IP addresses.
+    - **Reserved service CIDR ranges**: `10.10.64.0/22` and `10.10.192.0/22` are reserved for AKS service CIDRs. Each block provides about 1,024 IP addresses.
+    - **Plan for future expansion**: If you need extended networking later, plan AKS CIDR ranges now. Contact the Public Cloud team early for address planning support.
+
+> **Need help or unsure about your AKS networking setup?**
+> Contact the Public Cloud team through [Jira Service Management (JSM)](https://citz-do.atlassian.net/servicedesk/customer/portal/3). See [Support options](../../welcome/support.md) for more details.
 
 ## DNS
 
-In AKS, CoreDNS by default forwards all external queries to the Azure-provided DNS endpoint at `168.63.129.16` unless you’ve overridden the VNet DNS settings. In our Landing Zones, we have configured the VNet DNS servers to point to the Azure Firewall DNS proxy.
+In AKS, CoreDNS forwards external queries to `168.63.129.16` by default. This changes only when you override VNet DNS settings. In Landing Zones, VNet DNS servers point to the Azure Firewall DNS proxy.
 
-When your AKS nodes and pods use Azure CNI, they inherit DNS servers from the virtual network. By default, AKS **does not** enable Azure CNI Overlay. Azure CNI Overlay is only applied when you pass both `--network-plugin azure` and `--network-plugin-mode overlay` during deployment.
+When AKS nodes and pods use Azure CNI, they inherit DNS servers from the virtual network. AKS does not enable Azure CNI Overlay by default. It applies only when you pass `--network-plugin azure` and `--network-plugin-mode overlay`.
 
 !!! tip "Recommendation"
-    We strongly recommend using Azure CNI Overlay for AKS clusters to ensure proper DNS resolution and network performance. If you are experiencing issues with DNS resolution in your AKS cluster, it may be due to the absence of Azure CNI Overlay.
+    Use Azure CNI Overlay for AKS clusters. It helps DNS resolution and network performance.
 
-If you encounter DNS failures — such as `cert-manager` hanging on ACME validation despite CoreDNS being healthy — you can override the nameservers in the `cert-manager` pod spec.
+If DNS fails, `cert-manager` can stall on ACME validation even when CoreDNS is healthy. You can override nameservers in the `cert-manager` pod spec.
 
 ```yaml
 spec:
@@ -30,6 +40,22 @@ spec:
           - 10.53.244.4 # Azure Firewall DNS proxy
 ```
 
+## Security recommendations
+
+Use these AKS settings to improve cluster security. Some settings are required in Landing Zones. Others are optional and recommended for production workloads.
+
+- **Use Azure CNI Overlay**: Improve network isolation and reduce IP conflict risk.
+- **Use multiple availability zones**: Improve resiliency and support high availability during zone failures.
+- **Enable Entra ID authentication**: Use centralized identities to control cluster access.
+- **Disable local accounts**: Reduce unauthorized access risk and require Entra ID sign-in.
+- **Use Workload Identity and OIDC for pods**: Let workloads access Azure resources without stored secrets.
+- **Enable Key Vault and Azure Policy integration**: Secure secret handling and enforce policy controls.
+- **Enable Image Cleaner**: Remove unused images and reduce attack surface.
+- **Enable Advanced Container Networking Services (ACNS)**: Apply stronger network controls, including policies and micro-segmentation.
+- **Enable Cilium dataplane**: Improve policy enforcement and network visibility.
+
+## Best practices and further reading
+
 For more information and best practices, see:
 
 - [AKS Networking Concepts](https://learn.microsoft.com/en-us/azure/aks/concepts-network)
@@ -39,15 +65,12 @@ For more information and best practices, see:
 - [Azure CNI Pod Subnet](https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-pod-subnet)
 
 !!! info "Recommended reading"
-    If you are planning on deploying Azure Kubernetes Service (AKS) in your Landing Zone, the following book is highly recommended based on the **real-world production experience** insights shared by the author, especially around decisions that are **impossible to fix without rebuilding the cluster**.
-    
+    If you plan to deploy AKS in a Landing Zone, this book can help. It shares production lessons and calls out decisions that require a cluster rebuild.
+
     - [The AKS Book: The Real-World Guide to Azure Kubernetes Service](https://www.amazon.ca/dp/B0GNNVSG67)
 
     Example insights:
 
-    - **Use Azure CNI Overlay with Cilium**: This provides faster packet processing, more efficient network policy enforcement (L3/L4 and L7), improved service routing, better observability of cluster traffic, and support for larger clusters.
-    - **Plan your CIDR ranges carefully**: Network CIDRs cannot be changed after cluster creation. The pod CIDR, service CIDR, and DNS service IP you choose at creation are permanent. If these ranges overlap with external networks you need to reach (VNet address space, peered VNets, on-premises networks via VPN/ExpressRoute), the cluster’s routing rules treat those destination IPs as internal Kubernetes services. This is impossible to fix without rebuilding the cluster.
-    - **Use availability zones** (1, 2, 3) for your AKS system and user node pools in all clusters, including dev and test environments, to improve resiliency.
-
-> **Need help or unsure about your AKS networking setup?**
-> Reach out to the Public Cloud team for advice via [Jira Service Management (JSM)](https://citz-do.atlassian.net/servicedesk/customer/portal/3). See [Support options](../../welcome/support.md) for more details.
+    - **Use Azure CNI Overlay with Cilium**: Improve packet processing, policy enforcement, service routing, and traffic visibility.
+    - **Plan CIDR ranges before deployment**: You cannot change pod CIDR, service CIDR, or DNS service IP after cluster creation. Overlap with external networks can force a full cluster rebuild.
+    - **Use availability zones (1, 2, 3)**: Apply this to system and user node pools in all environments.


### PR DESCRIPTION
This pull request updates the AKS (Azure Kubernetes Service) documentation to clarify networking and security best practices, provide more actionable recommendations, and improve guidance on planning for reliability and future growth. The changes reorganize content for clarity, add new security recommendations, and update best practice advice with a focus on real-world production experience.

**Key improvements include:**

### Networking guidance and planning
- Clarified the importance of unique, non-overlapping pod and service CIDR ranges, with updated reserved ranges and explicit guidance to contact the Public Cloud team for planning support.
- Updated warnings and tips to reflect current address space reservations and the process for subnet creation within pre-existing VNets.

### Security recommendations
- Added a new section outlining required and recommended AKS security settings, such as enabling Azure CNI Overlay, using multiple availability zones, Entra ID authentication, Workload Identity, and advanced networking features.

### DNS and networking best practices
- Simplified and clarified DNS configuration details, emphasizing the use of Azure CNI Overlay for improved DNS resolution and network performance.
- Provided actionable troubleshooting advice for DNS issues, especially for `cert-manager`.

### Best practices and further reading
- Updated best practice recommendations to emphasize decisions that are permanent after cluster creation, such as CIDR selection, and the importance of using Azure CNI Overlay with Cilium and availability zones.
- Improved the recommended reading section to highlight the value of learning from real-world production experience.