### PR TITLE
Updated MS Fabric Guidance for Data Foundations Team Engagement

### DIFF
--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -280,6 +280,15 @@ Before submitting documentation, verify:
 - [ ] Contractions are positive, not negative
 - [ ] Gender-neutral pronouns used
 
+## Review shortcut and shortcode
+
+Use these commands when you want a standards-based documentation review.
+
+- Shortcut: "Review this documentation against the repository documentation standards."
+- Shortcode: `/doc-review`
+
+When either command is used, review modified documentation files and report findings by severity with file and line references.
+
 ## References
 
 - [BC Government Writing Guide - Grammar, Spelling and Tone](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/grammar-spelling-tone)

--- a/docs/azure/azure-services/external-services.md
+++ b/docs/azure/azure-services/external-services.md
@@ -29,9 +29,9 @@ For more information, please refer to the [Power Platform - Set up pay-as-you-go
 !!! question "Do I really need Microsoft Fabric?"
     Before you request a project set in the Azure Landing Zone, contact the [DataFoundations team](mailto:NRM.DataFoundations@gov.bc.ca). They can confirm whether Microsoft Fabric is the best fit for your project.
 
-If your on-premises data source has a **public endpoint**, you can connect Microsoft Fabric directly. You do not need to [provision a project set](../../welcome/provision-a-project-set.md) in the Azure Landing Zone.
+If your on-premises data source uses a **public endpoint** or a **private endpoint**, [provision a project set](../../welcome/provision-a-project-set.md) in the Azure Landing Zone. You need this project set for your [Fabric capacity quota](https://learn.microsoft.com/en-us/fabric/enterprise/fabric-quotas?tabs=Azure).
 
-If your on-premises data source needs a **private connection**, [provision a project set](../../welcome/provision-a-project-set.md) in the Azure Landing Zone. This setup creates a secure connection between Microsoft Fabric and your on-premises data source.
+To connect Microsoft Fabric to your on-premises data source, deploy a [Virtual Network Data Gateway](https://learn.microsoft.com/en-us/data-integration/gateway/). You can deploy the gateway in your Azure Landing Zone or on-premises. The gateway provides secure data transfer between Microsoft Fabric and your on-premises data source.
 
 !!! info "Private Link Service Direct Connect (PLSDC)"
     [Private Link Service Direct Connect (PLSDC)](https://learn.microsoft.com/en-us/azure/private-link/configure-private-link-service-direct-connect) is in public preview. Microsoft does not yet support it in Canadian Azure regions.

--- a/docs/azure/azure-services/external-services.md
+++ b/docs/azure/azure-services/external-services.md
@@ -24,16 +24,19 @@ For more information, please refer to the [Power Platform - Set up pay-as-you-go
 
 ## Microsoft Fabric
 
-[Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/fundamentals/microsoft-fabric-overview) is a unified analytics platform. It combines services such as Data Factory, Synapse Analytics, and Power BI. The service runs outside Azure, but you can integrate it with Azure services for analytics and data workflows.
+[Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/fundamentals/microsoft-fabric-overview) is a unified analytics platform. It includes services such as [Data Factory](https://learn.microsoft.com/en-us/azure/data-factory/introduction), [Synapse Analytics](https://learn.microsoft.com/en-us/azure/synapse-analytics/overview-what-is), and [Power BI](https://learn.microsoft.com/en-us/power-bi/fundamentals/power-bi-overview). It runs outside Azure. You can still integrate it with Azure services for analytics and data workflows.
+
+!!! question "Do I really need Microsoft Fabric?"
+    Before you request a project set in the Azure Landing Zone, contact the [DataFoundations team](mailto:NRM.DataFoundations@gov.bc.ca). They can confirm whether Microsoft Fabric is the best fit for your project.
 
 If your on-premises data source has a **public endpoint**, you can connect Microsoft Fabric directly. You do not need to [provision a project set](../../welcome/provision-a-project-set.md) in the Azure Landing Zone.
 
 If your on-premises data source needs a **private connection**, [provision a project set](../../welcome/provision-a-project-set.md) in the Azure Landing Zone. This setup creates a secure connection between Microsoft Fabric and your on-premises data source.
 
 !!! info "Private Link Service Direct Connect (PLSDC)"
-    [Private Link Service Direct Connect (PLSDC)](https://learn.microsoft.com/en-us/azure/private-link/configure-private-link-service-direct-connect) is in public preview. Microsoft does not support it yet in Canadian Azure regions.
+    [Private Link Service Direct Connect (PLSDC)](https://learn.microsoft.com/en-us/azure/private-link/configure-private-link-service-direct-connect) is in public preview. Microsoft does not yet support it in Canadian Azure regions.
 
-    When Microsoft enables PLSDC in Canadian Azure regions, you can use a simpler private connection path for Microsoft Fabric. For more detail, read [Connecting Microsoft Fabric to on-premises databases with Private Link](https://blog.cloudtrooper.net/2026/02/25/connecting-microsoft-fabric-to-on-premises-databases-with-private-link/).
+    When Microsoft enables PLSDC in Canadian Azure regions, you can use a simpler private connection path for Microsoft Fabric. For more details, read [Connecting Microsoft Fabric to on-premises databases with Private Link](https://blog.cloudtrooper.net/2026/02/25/connecting-microsoft-fabric-to-on-premises-databases-with-private-link/).
 
 ## Azure Databricks and Unity Catalog
 


### PR DESCRIPTION
This pull request introduces improvements to documentation standards and enhances guidance for Microsoft Fabric integration in Azure. The main changes include the addition of documentation review shortcuts and expanded, clearer instructions for evaluating and connecting Microsoft Fabric to Azure services.

Documentation standards and review process:

* Added a new section to `.github/instructions/documentation.instructions.md` describing shortcut and shortcode commands for standards-based documentation review, including instructions on how to use them and what to expect from the review process.

Microsoft Fabric guidance and clarity:

* Expanded the description of Microsoft Fabric in `docs/azure/azure-services/external-services.md` to include direct links to its main components (`Data Factory`, `Synapse Analytics`, and `Power BI`), and clarified integration with Azure services.
* Added a "Do I really need Microsoft Fabric?" advisory note, instructing users to consult the DataFoundations team before requesting a project set, to ensure Microsoft Fabric is the right choice for their project.
* Improved language and detail in the section on Private Link Service Direct Connect (PLSDC), clarifying its support status in Canadian Azure regions and refining explanations for private connection setup.