### PR TITLE
Add AVD documentation and update writing instructions

### DIFF
--- a/.github/instructions/copilot-workflow.instructions.md
+++ b/.github/instructions/copilot-workflow.instructions.md
@@ -27,3 +27,5 @@ If Copilot-generated summary is not available in the current toolchain, use a ma
 ## Documentation naming convention
 
 In this repository, treat "Public Cloud team" as a formal name and keep this capitalization in documentation updates.
+
+When updating or reviewing documentation with MkDocs admonitions, validate that `!!!` blocks use aligned 4-space indentation and supported admonition types.

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -238,7 +238,24 @@ Use MkDocs Material admonitions for important information:
     Here's a helpful suggestion
 ```
 
-Available types: note, info, tip, warning, danger, example, quote
+Admonition content must be indented with exactly 4 spaces under each `!!!` line.
+Keep indentation aligned for all body lines in the same admonition block.
+
+Supported types:
+- note
+- abstract
+- info
+- tip
+- success
+- question
+- warning
+- failure
+- danger
+- bug
+- example
+- quote
+
+Reference: [MkDocs Material admonitions - supported types](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types)
 
 ## Content organization
 
@@ -279,6 +296,8 @@ Before submitting documentation, verify:
 - [ ] Paragraphs are 5 sentences or less
 - [ ] Contractions are positive, not negative
 - [ ] Gender-neutral pronouns used
+- [ ] Every `!!!` admonition block uses 4-space aligned indentation
+- [ ] Admonition types are valid for MkDocs Material
 
 ## Review shortcut and shortcode
 
@@ -288,6 +307,7 @@ Use these commands when you want a standards-based documentation review.
 - Shortcode: `/doc-review`
 
 When either command is used, review modified documentation files and report findings by severity with file and line references.
+When reviewing, explicitly check `!!!` admonition indentation and supported type usage.
 
 ## Repository workflow standards
 
@@ -307,6 +327,7 @@ Apply these standards when working in this repository:
 - [BC Government Writing Guide - Writing Web Content](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/writing-web-content)
 - [BC Government Writing Guide - Capitalization](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/capitalization)
 - [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/WAI/WCAG20/quickref/)
+- [MkDocs Material admonitions - supported types](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types)
 
 ---
 

--- a/docs/aws/LZA/design-build-deploy/networking-direct-connect.md
+++ b/docs/aws/LZA/design-build-deploy/networking-direct-connect.md
@@ -16,4 +16,4 @@ In our setup, DirectConnect also encrypts data in transit with IPsec. This ensur
 
 ## AWS to on-premises connectivity
 
-To connect an AWS virtual private cloud network to an on-premises network, refer to the [Shared Services - Multi-Cloud Connect Service (MCCS)](../../../shared-services/mccs/mccs.md) documentation.
+To connect an AWS virtual private cloud network to an on-premises network, refer to the [Shared Services - Multi-Cloud Connectivity Service (MCCS)](../../../shared-services/mccs/mccs.md) documentation.

--- a/docs/azure/azure-services/avd.md
+++ b/docs/azure/azure-services/avd.md
@@ -47,13 +47,13 @@ Your network design depends on where end users connect from.
 Most teams use one of these two AVD network architectures:
 
 1. **AVD with public endpoints**: AVD resources run in a VNet and use public endpoints for feed discovery and session access. Users can connect from anywhere without the B.C. government network.
-2. **AVD with private endpoints**: AVD resources run in a VNet and use [private link](https://learn.microsoft.com/en-us/azure/virtual-desktop/private-link-overview) for host pool and session host connectivity. Users connect through the B.C. government network, either on-premises or through VPN.
+2. **AVD with private endpoints**: AVD resources run in a VNet and use [Private Link](https://learn.microsoft.com/en-us/azure/virtual-desktop/private-link-overview) for host pool and session host connectivity. Users connect through the B.C. government network, either on-premises or through VPN.
 
-!!! warning "Public Endpoint Security Policies"
+!!! warning "Public endpoint security policies"
     If you plan to deploy AVD with public endpoints, submit a [support request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team.
     Security policies block public endpoint deployment for AVD host pools and workspaces by default.
 
-!!! example "Deploying AVD in a Landing Zone"
+!!! example "Deploying AVD in a landing zone"
     Microsoft provides a [QuickStart template](https://learn.microsoft.com/en-us/azure/virtual-desktop/quickstart?tabs=windows) for AVD deployment.
 
     The template deploys some resources that already exist in Azure Landing Zones, such as the virtual network. It also omits supporting resources that most production deployments need, such as Key Vault, Log Analytics, FSLogix storage accounts, and scaling plans.
@@ -73,3 +73,9 @@ For more information and best practices, see:
 - [Security recommendations for Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/security-recommendations)
 - [Understanding Azure Virtual Desktop network connectivity](https://learn.microsoft.com/en-us/azure/virtual-desktop/network-connectivity)
 - [Apply Zero Trust principles to an Azure Virtual Desktop deployment](https://learn.microsoft.com/en-us/security/zero-trust/azure-infrastructure-avd?context=/azure/virtual-desktop/context/context)
+
+## Related pages
+
+- [Networking](../design-build-deploy/networking.md)
+- [Deploy to the Azure landing zone](../design-build-deploy/deploy-to-the-azure-landing-zone.md)
+- [User management](../design-build-deploy/user-management.md)

--- a/docs/azure/azure-services/avd.md
+++ b/docs/azure/azure-services/avd.md
@@ -1,0 +1,75 @@
+# Azure Virtual Desktop (AVD)
+
+Last updated: **{{ git_revision_date_localized }}**
+
+Azure Virtual Desktop (AVD) is a desktop and app virtualization service that runs on Azure.
+It lets users access virtual desktops and applications from anywhere on any device.
+AVD supports remote work with secure, scalable access and centralized IT control.
+
+---
+
+## High-level end-user connectivity flow
+
+1. User signs in to the AVD client
+   - They open the Windows Desktop Client, Web Client, or Remote Desktop app.
+   - They authenticate with Entra ID.
+2. AVD queries the user’s Workspaces
+   - A **Workspace** is just a container that groups application groups for the user.
+     - The client asks AVD: "**Which Workspaces does this user have access to?**"
+     - AVD returns the list of Workspaces the user is subscribed to.
+3. Workspace returns the user’s Application Groups
+   - Inside each Workspace are **Application Groups**, which define what the user can launch:
+     - **Desktop Application Group (DAG)** → full desktop
+     - **RemoteApp Application Group (RAG)** → individual apps
+   - The Workspace tells the client: "**Here are the desktops and apps this user is allowed to see.**"
+4. Application Group maps the user to a Host Pool
+   - Each Application Group is linked to **one Host Pool**.
+   - The DAG/RAG says: "**This user belongs to this Host Pool.**"
+   - This is the key relationship: `Workspace -> Application Group -> Host Pool -> Session Hosts`
+5. Host Pool selects a Session Host
+   - The Host Pool decides which _**VM**_ the user should land on:
+     - **Breadth-first** → spread users evenly
+     - **Depth-first** → fill one VM before moving to the next
+     - **Persistent** (personal) → always the same VM
+   - The Host Pool returns the chosen session host to the AVD broker.
+6. User connects through the AVD control plane
+   - The user **never connects directly** to the VM’s IP.
+   - Instead:
+     - The AVD broker establishes a **reverse connection** from the VM to the user.
+     - Traffic flows through **AVD’s secure control plane**, not your VNet.
+   - This is why AVD works even without public IPs.
+7. User receives their desktop or app
+   - The session host VM accepts the connection and starts the user session.
+
+## Networking
+
+Your network design depends on where end users connect from.
+Most teams use one of these two AVD network architectures:
+
+1. **AVD with public endpoints**: AVD resources run in a VNet and use public endpoints for feed discovery and session access. Users can connect from anywhere without the B.C. government network.
+2. **AVD with private endpoints**: AVD resources run in a VNet and use [private link](https://learn.microsoft.com/en-us/azure/virtual-desktop/private-link-overview) for host pool and session host connectivity. Users connect through the B.C. government network, either on-premises or through VPN.
+
+!!! warning "Public Endpoint Security Policies"
+    If you plan to deploy AVD with public endpoints, submit a [support request](https://citz-do.atlassian.net/servicedesk/customer/portal/3) to the Public Cloud team.
+    Security policies block public endpoint deployment for AVD host pools and workspaces by default.
+
+!!! example "Deploying AVD in a Landing Zone"
+    Microsoft provides a [QuickStart template](https://learn.microsoft.com/en-us/azure/virtual-desktop/quickstart?tabs=windows) for AVD deployment.
+
+    The template deploys some resources that already exist in Azure Landing Zones, such as the virtual network. It also omits supporting resources that most production deployments need, such as Key Vault, Log Analytics, FSLogix storage accounts, and scaling plans.
+
+    We created a Terraform module to support Azure Virtual Desktop deployments. It deploys AVD resources, including host pools, session hosts, application groups, workspaces, scaling plans, and FSLogix storage accounts. It also deploys supporting resources such as Key Vault and Log Analytics with diagnostics enabled.
+
+    The module deploys into an existing virtual network, such as one from Azure Landing Zones, and creates the required subnets and network security groups for AVD.
+
+    You can find this module in the [Azure Landing Zone Samples](https://github.com/bcgov/azure-lz-samples) repository under `/applications/azure_virtual_desktop/`. Review the module [README](https://github.com/bcgov/azure-lz-samples/blob/main/applications/azure_virtual_desktop/README.md) for setup instructions.
+
+## Best practices and further reading
+
+For more information and best practices, see:
+
+- [Prerequisites for Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/prerequisites?tabs=portal)
+- [Azure Virtual Desktop service architecture and resilience](https://learn.microsoft.com/en-us/azure/virtual-desktop/service-architecture-resilience)
+- [Security recommendations for Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/security-recommendations)
+- [Understanding Azure Virtual Desktop network connectivity](https://learn.microsoft.com/en-us/azure/virtual-desktop/network-connectivity)
+- [Apply Zero Trust principles to an Azure Virtual Desktop deployment](https://learn.microsoft.com/en-us/security/zero-trust/azure-infrastructure-avd?context=/azure/virtual-desktop/context/context)

--- a/docs/azure/design-build-deploy/deploy-to-the-azure-landing-zone.md
+++ b/docs/azure/design-build-deploy/deploy-to-the-azure-landing-zone.md
@@ -46,7 +46,7 @@ GitHub Actions is a feature of GitHub that allows you to automate your workflow.
 
 ## Infrastructure-as-Code (IaC)
 
-There are multiple ways to deploy your application to the Azure Landing Zone using Infrastructure-as-Code (IaC). You can use tools like [Terraform](https://www.terraform.io/), [Azure Resource Manager (ARM) templates](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/), [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep), [Ansible](https://learn.microsoft.com/en-us/azure/developer/ansible/overview), [Chef](https://learn.microsoft.com/en-us/azure/developer/chef/overview), or [Pulumi](https://devblogs.microsoft.com/devops/infrastructure-as-code-azure-python-wpulumi/) to define your Infrastructure-as-Code and deploy it to Azure.
+There are multiple ways to deploy your application to the Azure Landing Zone using Infrastructure-as-Code (IaC). You can use tools like [Terraform](https://www.terraform.io/), [Azure Resource Manager (ARM) templates](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/), [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep), [Ansible](https://learn.microsoft.com/en-us/azure/developer/ansible/overview), [Chef](https://www.chef.io/solutions/detail/chef-and-azure), or [Pulumi](https://devblogs.microsoft.com/devops/infrastructure-as-code-azure-python-wpulumi/) to define your Infrastructure-as-Code and deploy it to Azure.
 
 While we don't have a specific example for each tool, we recommend that you choose the tool that you are most comfortable with and that best fits your needs.
 

--- a/docs/azure/design-build-deploy/networking-express-route.md
+++ b/docs/azure/design-build-deploy/networking-express-route.md
@@ -16,7 +16,7 @@ In our setup, ExpressRoute also encrypts data in transit with IPsec. This ensure
 
 ## Azure to on-premises connectivity
 
-To connect an Azure virtual network to an on-premises network, refer to the [Shared Services - Multi-Cloud Connect Service (MCCS)](../../shared-services/mccs/mccs.md) documentation.
+To connect an Azure virtual network to an on-premises network, refer to the [Shared Services - Multi-Cloud Connectivity Service (MCCS)](../../shared-services/mccs/mccs.md) documentation.
 
 ## On-premises to Azure connectivity
 

--- a/docs/azure/tools/bastion.md
+++ b/docs/azure/tools/bastion.md
@@ -5,7 +5,7 @@ Last updated: **{{ git_revision_date_localized }}**
 Azure Bastion is a fully managed PaaS service that you provision to securely connect to virtual machines via private IP address. It provides secure and seamless RDP/SSH connectivity to your virtual machines directly over TLS from the Azure portal.
 
 !!! warning "Bastion session cached credentials"
-When you use a Virtual Machine in a VNet to access the Azure portal, the browser may cache your credentials. If your team shares the VM, it is **strongly recommended** to use a **private browser session** (incognito mode) or make sure you **log out** of the Azure portal after each session. Otherwise, other users could access your cached credentials.
+    When you use a Virtual Machine in a VNet to access the Azure portal, the browser may cache your credentials. If your team shares the VM, it is **strongly recommended** to use a **private browser session** (incognito mode) or make sure you **log out** of the Azure portal after each session. Otherwise, other users could access your cached credentials.
 
 !!! question "Which Azure Bastion SKU to use?"
     The minimum Bastion SKU required is **Developer**, where the `AzureBastionSubnet` subnet is not required. However, some features are limited or not available with this SKU. Please review the Microsoft [Bastion SKU](https://learn.microsoft.com/en-us/azure/bastion/configuration-settings#skus) documentation to determine the best SKU for your needs.

--- a/docs/shared-services/mccs/mccs.md
+++ b/docs/shared-services/mccs/mccs.md
@@ -1,4 +1,4 @@
-# Multi-Cloud Connect Service (MCCS)
+# Multi-Cloud Connectivity Service (MCCS)
 
 Last updated: **{{ git_revision_date_localized }}**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
           - Azure Kubernetes Service: azure/azure-services/aks.md
           - Azure SQL Database: azure/azure-services/sql-database.md
           - Azure SQL Managed Instance: azure/azure-services/sql-managed-instance.md
+          - Azure Virtual Desktop: azure/azure-services/avd.md
           - Databricks: azure/azure-services/databricks.md
           - External Microsoft Services: azure/azure-services/external-services.md
       - Operational guidance:


### PR DESCRIPTION
This pull request introduces several documentation improvements and new content, focusing on Azure Virtual Desktop (AVD) guidance, MkDocs admonition standards, and consistent naming for the Multi-Cloud Connectivity Service (MCCS). The most significant changes are the addition of a comprehensive AVD overview, stricter standards for documentation formatting, and updates to ensure consistent terminology across cloud connectivity documentation.

**New Azure Virtual Desktop documentation:**

* Added a new `docs/azure/azure-services/avd.md` file providing an overview, connectivity flow, networking options, deployment guidance, and best practices for Azure Virtual Desktop. This includes details on user authentication, session brokering, networking architectures, and links to further resources.
* Updated the navigation in `mkdocs.yml` to include the new Azure Virtual Desktop documentation page.

**Documentation standards and formatting:**

* Enhanced documentation instructions to require 4-space indentation for all MkDocs admonition (`!!!`) blocks and to use only supported admonition types. Added a checklist for reviewers and explicit review instructions for these standards. [[1]](diffhunk://#diff-3298abcaf683d5d9edc5366e93870fa3038b8d515339f36983cf1432bb46a6c4L241-R258) [[2]](diffhunk://#diff-3298abcaf683d5d9edc5366e93870fa3038b8d515339f36983cf1432bb46a6c4R299-R300) [[3]](diffhunk://#diff-3298abcaf683d5d9edc5366e93870fa3038b8d515339f36983cf1432bb46a6c4R310) [[4]](diffhunk://#diff-862d304574074a0ae0235a16f96e93195fd29d026aef2dbaffd8e3c12f9e6cfeR30-R31)
* Added a reference link to the MkDocs Material admonitions supported types in documentation standards.

**Terminology consistency:**

* Updated all references and headings from "Multi-Cloud Connect Service (MCCS)" to "Multi-Cloud Connectivity Service (MCCS)" in both AWS and Azure networking documentation and the shared services MCCS documentation. [[1]](diffhunk://#diff-6e9d26b61bc14d59de7561dbf67aade54cde11283d9e1c8934706e0961ba7746L19-R19) [[2]](diffhunk://#diff-fa4eaf069860c14fdc4d6205ad3b2c0e95e4d2d8957fd3cb3f920c2952ebf000L19-R19) [[3]](diffhunk://#diff-e2c6005ce6ac54111449944523837fbf1ade4466f12894d8e5d50708f96e5c7cL1-R1)