### PR TITLE
Databricks Guidance Updates

### DIFF
--- a/docs/azure/azure-services/external-azure-devops.md
+++ b/docs/azure/azure-services/external-azure-devops.md
@@ -4,6 +4,11 @@ Last updated: **{{ git_revision_date_localized }}**
 
 This page explains how to use Azure DevOps with Azure subscriptions in the Azure Landing Zone.
 
+!!! question "What does "external" mean in this context?"
+    The term "external" is used to indicate that these service's **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
+
+    Azure may be used to provide compute, storage, capacity, billing, etc. for these services.
+
 ---
 
 ## Azure DevOps

--- a/docs/azure/azure-services/external-databricks.md
+++ b/docs/azure/azure-services/external-databricks.md
@@ -4,15 +4,22 @@ Last updated: **{{ git_revision_date_localized }}**
 
 This page explains how Azure Databricks and Unity Catalog work in our environment. It also describes the current Unity Catalog status for the B.C. government.
 
+!!! question "What does "external" mean in this context?"
+    The term "external" is used to indicate that these service's **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
+
+    Azure may be used to provide compute, storage, capacity, billing, etc. for these services.
+
 ---
 
 ## Azure Databricks and Unity Catalog
 
 While the [Azure Databricks Workspace](https://learn.microsoft.com/en-us/azure/databricks/introduction/) is an Azure resource managed through the Azure Resource Manager, some of its advanced features, like [Unity Catalog](https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/), operate outside the standard Azure management plane.
 
+Every Azure Databrick Account exists at the **Azure tenant** level, **not** the subscription level. This means a single Databricks account can span across multiple Azure subscriptions.
+
 Unity Catalog provides a centralized data governance layer for Databricks assets but is managed through the **Databricks control plane** via the [Databricks account console](https://accounts.azuredatabricks.net), not through the Azure Portal.
 
-| Feature                           | Owned/Managed by         | Lives in Azure? | Lives in Databricks? |
+| Feature                           | Owned / Managed by         | Managed in Azure portal? | Managed in Databricks account console? |
 | --------------------------------- | ------------------------ | --------------- | -------------------- |
 | **Azure Databricks Workspace**    | Azure Resource Manager   | ✅ Yes          | ✅ Yes (shared)      |
 | **Unity Catalog**                 | Databricks Control Plane | ❌ No           | ✅ Yes               |
@@ -49,3 +56,9 @@ If Unity Catalog is introduced in the future, a central **data governance functi
 - Control cross-workspace access policies.
 - Maintain consistent audit and lineage tracking.
 - Coordinate identity integration with Microsoft Entra ID.
+
+## References
+
+- [Understanding Key Layers of the Azure Databricks Account](https://www.linkedin.com/pulse/understanding-key-layers-azure-databricks-account-julia-f%C3%B8rde-wjp9f)
+- [Databricks data residency](https://learn.microsoft.com/en-us/azure/databricks/resources/databricks-geos)
+- [High-level Databricks architecture](https://learn.microsoft.com/en-us/azure/databricks/getting-started/high-level-architecture)

--- a/docs/azure/azure-services/external-databricks.md
+++ b/docs/azure/azure-services/external-databricks.md
@@ -4,8 +4,8 @@ Last updated: **{{ git_revision_date_localized }}**
 
 This page explains how Azure Databricks and Unity Catalog work in our environment. It also describes the current Unity Catalog status for the B.C. government.
 
-!!! question "What does "external" mean in this context?"
-    The term "external" is used to indicate that these service's **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
+!!! question "What does 'external' mean in this context?"
+    The term "external" is used to indicate that the service **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
 
     Azure may be used to provide compute, storage, capacity, billing, etc. for these services.
 
@@ -15,11 +15,11 @@ This page explains how Azure Databricks and Unity Catalog work in our environmen
 
 While the [Azure Databricks Workspace](https://learn.microsoft.com/en-us/azure/databricks/introduction/) is an Azure resource managed through the Azure Resource Manager, some of its advanced features, like [Unity Catalog](https://learn.microsoft.com/en-us/azure/databricks/data-governance/unity-catalog/), operate outside the standard Azure management plane.
 
-Every Azure Databrick Account exists at the **Azure tenant** level, **not** the subscription level. This means a single Databricks account can span across multiple Azure subscriptions.
+Every Azure Databricks Account exists at the **Azure tenant** level, **not** the subscription level. This means a single Databricks account can span across multiple Azure subscriptions.
 
 Unity Catalog provides a centralized data governance layer for Databricks assets but is managed through the **Databricks control plane** via the [Databricks account console](https://accounts.azuredatabricks.net), not through the Azure Portal.
 
-| Feature                           | Owned / Managed by         | Managed in Azure portal? | Managed in Databricks account console? |
+| Feature                           | Owned / Managed by         | Managed in Azure Portal? | Managed in Databricks account console? |
 | --------------------------------- | ------------------------ | --------------- | -------------------- |
 | **Azure Databricks Workspace**    | Azure Resource Manager   | ✅ Yes          | ✅ Yes (shared)      |
 | **Unity Catalog**                 | Databricks Control Plane | ❌ No           | ✅ Yes               |
@@ -57,7 +57,7 @@ If Unity Catalog is introduced in the future, a central **data governance functi
 - Maintain consistent audit and lineage tracking.
 - Coordinate identity integration with Microsoft Entra ID.
 
-## References
+## Related pages
 
 - [Understanding Key Layers of the Azure Databricks Account](https://www.linkedin.com/pulse/understanding-key-layers-azure-databricks-account-julia-f%C3%B8rde-wjp9f)
 - [Databricks data residency](https://learn.microsoft.com/en-us/azure/databricks/resources/databricks-geos)

--- a/docs/azure/azure-services/external-fabric.md
+++ b/docs/azure/azure-services/external-fabric.md
@@ -4,6 +4,11 @@ Last updated: **{{ git_revision_date_localized }}**
 
 This page explains how Microsoft Fabric connects with Azure services and private networking in the Azure Landing Zone.
 
+!!! question "What does "external" mean in this context?"
+    The term "external" is used to indicate that these service's **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
+
+    Azure may be used to provide compute, storage, capacity, billing, etc. for these services.
+
 ---
 
 ## Microsoft Fabric

--- a/docs/azure/azure-services/external-power-platform.md
+++ b/docs/azure/azure-services/external-power-platform.md
@@ -4,6 +4,11 @@ Last updated: **{{ git_revision_date_localized }}**
 
 This page explains how to use Power Platform services with Azure subscription billing in the Azure Landing Zone.
 
+!!! question "What does "external" mean in this context?"
+    The term "external" is used to indicate that these service's **control plane** and **management interface** are **outside** the Azure Portal. They are still Azure services, but they have their own management plane.
+
+    Azure may be used to provide compute, storage, capacity, billing, etc. for these services.
+
 ---
 
 ## Power Platform


### PR DESCRIPTION
This pull request improves documentation clarity for several Azure service overview pages by introducing a consistent explanation of what "external" means in the context of Azure services. Additionally, the Databricks documentation is enhanced with further details and references regarding account scope and management layers.

Documentation consistency and clarity:

* Added a standardized "What does 'external' mean in this context?" callout to the top of the following pages: `external-azure-devops.md`, `external-databricks.md`, `external-fabric.md`, and `external-power-platform.md`. This clarifies that "external" services have their control plane and management interface outside the Azure Portal, though they may still use Azure resources. [[1]](diffhunk://#diff-793a26f6561ee4e6a32f898aa8c438e05d6db5bc933170ca41d1cb861f7354b7R7-R11) [[2]](diffhunk://#diff-63301f25d3d74b4b5451152aa848dd59f7863eb20c0601455e4b95e11c62bafdR7-R22) [[3]](diffhunk://#diff-844968f407e933032c6cb3f79ad71d506d5f502e950a6232f389fda5608dd8a1R7-R11) [[4]](diffhunk://#diff-88ae526fa1328c252b0eba47eec992ac6c77d64a87c8614c6f2682ebbfea3f22R7-R11)

Databricks documentation enhancements:

* Explained that every Azure Databricks account exists at the Azure tenant level (not the subscription level), emphasizing cross-subscription management.
* Improved the features comparison table for clarity, renaming columns to better reflect where management occurs.
* Added a references section with links to further reading on Databricks account layers, data residency, and architecture.