### PR TITLE
Added default pod CIDR for AKS

### DIFF
--- a/docs/azure/azure-services/aks.md
+++ b/docs/azure/azure-services/aks.md
@@ -21,12 +21,12 @@ When you deploy AKS clusters, keep service and pod CIDR ranges unique. Do not ov
     - **Reserved AKS CIDR pair 1**: Use pod CIDR `10.10.0.0/18` with service CIDR `10.10.64.0/22`. The pod block provides about 16,384 IP addresses, and the service block provides about 1,024 IP addresses.
     - **Reserved AKS CIDR pair 2**: Use pod CIDR `10.10.128.0/18` with service CIDR `10.10.192.0/22`. The pod block provides about 16,384 IP addresses, and the service block provides about 1,024 IP addresses.
 
-    **Important**: Each AKS cluster should use one complete reserved pod/service CIDR pair. Do not mix a pod CIDR from one pair with a service CIDR from the other pair.
+    **Important**: When you specify a custom pod CIDR, use one complete reserved pod/service CIDR pair. Do not mix a pod CIDR from one pair with a service CIDR from the other pair.
 
     !!! note "Default pod CIDR range"
-        Whether you're using the Azure portal or IaC/CLI to deploy AKS if you do not specify a pod CIDR range, Azure will assign the default pod CIDR range of `10.244.0.0/16`.
+        If you do not specify a pod CIDR range when deploying AKS (Azure portal or IaC/CLI), Azure will assign the default pod CIDR range of `10.244.0.0/16`.
         
-        This is also an acceptable pod CIDR range for Landing Zone AKS clusters, even though it is not paired with a service CIDR range.
+        This default pod CIDR range is acceptable for Landing Zone AKS clusters, but it is not part of a reserved pod/service CIDR pair.
         
         If you use the default pod CIDR range, you must still specify a service CIDR range from one of the reserved pairs.
 

--- a/docs/azure/azure-services/aks.md
+++ b/docs/azure/azure-services/aks.md
@@ -23,6 +23,13 @@ When you deploy AKS clusters, keep service and pod CIDR ranges unique. Do not ov
 
     **Important**: Each AKS cluster should use one complete reserved pod/service CIDR pair. Do not mix a pod CIDR from one pair with a service CIDR from the other pair.
 
+    !!! note "Default pod CIDR range"
+        Whether you're using the Azure portal or IaC/CLI to deploy AKS if you do not specify a pod CIDR range, Azure will assign the default pod CIDR range of `10.244.0.0/16`.
+        
+        This is also an acceptable pod CIDR range for Landing Zone AKS clusters, even though it is not paired with a service CIDR range.
+        
+        If you use the default pod CIDR range, you must still specify a service CIDR range from one of the reserved pairs.
+
 !!! warning "AKS pod CIDR control"
     The Azure portal AKS deployment experience does not currently support providing a custom pod CIDR range. To use the reserved CIDR ranges, you must deploy AKS using the command line or Infrastructure-as-Code (IaC).
 
@@ -40,7 +47,7 @@ When you deploy AKS clusters, keep service and pod CIDR ranges unique. Do not ov
     --dns-service-ip 10.10.64.10
     ```
 
-    > **Important:** See the [Security recommendations](#security-recommendations) section for additional recommended settings to include in your AKS deployment.
+    > **Important:** See the [Security requirements](#security-requirements) section for additional required settings to include in your AKS deployment.
 
 > **Need help or unsure about your AKS networking setup?**
 > Contact the Public Cloud team through [Jira Service Management (JSM)](https://citz-do.atlassian.net/servicedesk/customer/portal/3). See [Support options](../../welcome/support.md) for more details.
@@ -65,7 +72,7 @@ spec:
           - 10.53.244.4 # Azure Firewall DNS proxy
 ```
 
-## Security recommendations
+## Security requirements
 
 Use these AKS settings to improve cluster security. The following settings are **required** in Landing Zones.
 
@@ -79,7 +86,7 @@ Use these AKS settings to improve cluster security. The following settings are *
 - **Enable Cilium dataplane**: Improve policy enforcement and network visibility.
 
 !!! example "Example Azure CLI command"
-    The following command creates an AKS cluster with the required security and networking settings. Start with the AKS networking example earlier in this page, then add the following security-focused options. Adjust parameters like cluster name, resource group, VNet subnet ID, and identity as needed.
+    The following command creates an AKS cluster with the required security and networking settings. Start with the AKS networking example earlier in this page, then add the following security-focused configurations. Adjust parameters like cluster name, resource group, VNet subnet ID, and identity as needed.
 
     ```shell
     az aks create \
@@ -108,9 +115,7 @@ For more information and best practices, see:
 - [Azure CNI Pod Subnet](https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-pod-subnet)
 
 !!! info "Recommended reading"
-    If you plan to deploy AKS in a Landing Zone, this book can help. It shares production lessons and calls out decisions that require a cluster rebuild.
-
-    - [The AKS Book: The Real-World Guide to Azure Kubernetes Service](https://www.amazon.ca/dp/B0GNNVSG67)
+    If you plan to deploy AKS in a Landing Zone (especially for production use), [The AKS Book: The Real-World Guide to Azure Kubernetes Service](https://www.amazon.ca/dp/B0GNNVSG67) is a great resource. It shares production lessons and calls out important decisions that could later require a cluster rebuild!
 
     Example insights:
 


### PR DESCRIPTION
This pull request updates the AKS documentation to clarify networking defaults, strengthen security language, and improve resource recommendations. The main changes include a new note on the default pod CIDR range, reworded security sections to emphasize requirements, and clearer guidance on recommended reading.

**Networking and deployment guidance:**
* Added a note explaining that if you do not specify a pod CIDR range when deploying AKS, Azure assigns the default range `10.244.0.0/16`, which is acceptable for Landing Zone clusters, but you must still specify a service CIDR from a reserved pair.

**Security section improvements:**
* Changed the section title and references from "Security recommendations" to "Security requirements" to clarify that these settings are mandatory in Landing Zones. [[1]](diffhunk://#diff-e2c6e3f60e9f38a939f0be794aa0416a65c345b21e7c7b57a90676312dd165eaL43-R50) [[2]](diffhunk://#diff-e2c6e3f60e9f38a939f0be794aa0416a65c345b21e7c7b57a90676312dd165eaL68-R75)
* Updated language in the example CLI command to refer to "security-focused configurations" for clarity.

**Resource recommendations:**
* Improved the recommended reading note to highlight the value of "The AKS Book" for production Landing Zone deployments and clarified the importance of decisions that may require a cluster rebuild.