### PR TITLE
Added 'security requirements' corresponding to policies in place

### DIFF
--- a/docs/azure/azure-services/application-gateway.md
+++ b/docs/azure/azure-services/application-gateway.md
@@ -39,12 +39,12 @@ To use a private Application Gateway, **register** the `EnableApplicationGateway
 
 ## Security requirements
 
-The following security settings are **required** in Landing Zones.
+The following security settings are **required** in Landing Zones:
 
-- Application Gateway must have at least one **WAF policy** configured
-- Web Application Firewall (WAF) must be **enabled** for Application Gateway
-- Web Application Firewall (WAF) on Azure Application Gateway must have **request body inspection** enabled
-- **Bot protection** must be enabled in all Azure Application Gateway Web Application Firewall (WAF) policies
+- Application Gateway must have at least one **Web Application Firewall (WAF) policy** configured
+- WAF must be **enabled** for Application Gateway
+- WAF on Azure Application Gateway must have **request body inspection** enabled
+- **Bot protection** must be enabled in all Azure Application Gateway WAF policies
 
 ## Related pages
 

--- a/docs/azure/azure-services/application-gateway.md
+++ b/docs/azure/azure-services/application-gateway.md
@@ -37,6 +37,15 @@ To use a private Application Gateway, **register** the `EnableApplicationGateway
 
     ![Azure Application Gateway - Private IP Address](../images/private-app-gateway-ip-address.png "Azure Application Gateway - Private IP Address")
 
+## Security requirements
+
+The following security settings are **required** in Landing Zones.
+
+- Application Gateway for Containers has at least one **security policy** configured
+- Web Application Firewall (WAF) should be **enabled** for Application Gateway
+- Web Application Firewall on Azure Application Gateway should have **request body inspection** enabled
+- **Bot protection** is enabled in all Azure Application Gateway Web Application Firewall (WAF) policies
+
 ## Related pages
 
 - [Application Gateway overview](https://learn.microsoft.com/en-us/azure/application-gateway/overview)

--- a/docs/azure/azure-services/application-gateway.md
+++ b/docs/azure/azure-services/application-gateway.md
@@ -41,10 +41,10 @@ To use a private Application Gateway, **register** the `EnableApplicationGateway
 
 The following security settings are **required** in Landing Zones:
 
-- Application Gateway must have at least one **Web Application Firewall (WAF) policy** configured
+- Azure Application Gateway must have at least one **Web Application Firewall (WAF) policy** configured
 - WAF must be **enabled** for Application Gateway
-- WAF on Azure Application Gateway must have **request body inspection** enabled
-- **Bot protection** must be enabled in all Azure Application Gateway WAF policies
+- WAF on Application Gateway must have **request body inspection** enabled
+- **Bot protection** must be enabled in all Application Gateway WAF policies
 
 ## Related pages
 

--- a/docs/azure/azure-services/application-gateway.md
+++ b/docs/azure/azure-services/application-gateway.md
@@ -41,10 +41,10 @@ To use a private Application Gateway, **register** the `EnableApplicationGateway
 
 The following security settings are **required** in Landing Zones.
 
-- Application Gateway for Containers has at least one **security policy** configured
-- Web Application Firewall (WAF) should be **enabled** for Application Gateway
-- Web Application Firewall on Azure Application Gateway should have **request body inspection** enabled
-- **Bot protection** is enabled in all Azure Application Gateway Web Application Firewall (WAF) policies
+- Application Gateway must have at least one **WAF policy** configured
+- Web Application Firewall (WAF) must be **enabled** for Application Gateway
+- Web Application Firewall (WAF) on Azure Application Gateway must have **request body inspection** enabled
+- **Bot protection** must be enabled in all Azure Application Gateway Web Application Firewall (WAF) policies
 
 ## Related pages
 

--- a/docs/azure/azure-services/front-door.md
+++ b/docs/azure/azure-services/front-door.md
@@ -4,6 +4,19 @@ Last updated: **{{ git_revision_date_localized }}**
 
 Azure Front Door is a global entry point that uses the Microsoft edge network to deliver fast, secure, and highly scalable web applications. It provides dynamic site acceleration (DSA), SSL offloading, global load balancing with instant failover, and application layer security.
 
+## Security requirements
+
+The following security settings are **required** in Landing Zones.
+
+- Azure Front Door profiles should use **Premium tier** that supports managed WAF rules and private link
+- Azure Front Door Standard and Premium should be running **minimum TLS version of 1.2**
+- Web Application Firewall (WAF) on Azure Front Door should have **request body inspection** enabled
+- Web Application Firewall (WAF) should be enabled for Azure Front Door **entry-points**
+- **Bot Protection** should be enabled for Azure Front Door WAF
+- Web Application Firewall (WAF) **rate limit rule** for Azure Front Door should be enabled
+- Secure **private connectivity** between Azure Front Door Premium and Azure Storage Blob, or Azure App Service
+- Web Application Firewall (WAF) should use the specified **mode** (ie. **Prevention**) for Azure Front Door Service
+
 ## Deployment failures due to policy violation
 
 The Landing Zones have several policies that enforce the use of security best practices for Azure Front Door. When creating a Front Door, although the portal UI may report that validation passes, the deployment may fail due to policy violations.

--- a/docs/azure/azure-services/front-door.md
+++ b/docs/azure/azure-services/front-door.md
@@ -8,14 +8,14 @@ Azure Front Door is a global entry point that uses the Microsoft edge network to
 
 The following security settings are **required** in Landing Zones.
 
-- Azure Front Door profiles should use **Premium tier** that supports managed WAF rules and private link
-- Azure Front Door Standard and Premium should be running **minimum TLS version of 1.2**
-- Web Application Firewall (WAF) on Azure Front Door should have **request body inspection** enabled
-- Web Application Firewall (WAF) should be enabled for Azure Front Door **entry-points**
-- **Bot Protection** should be enabled for Azure Front Door WAF
-- Web Application Firewall (WAF) **rate limit rule** for Azure Front Door should be enabled
-- Secure **private connectivity** between Azure Front Door Premium and Azure Storage Blob, or Azure App Service
-- Web Application Firewall (WAF) should use the specified **mode** (ie. **Prevention**) for Azure Front Door Service
+- Azure Front Door profiles must use the **Premium tier** that supports managed WAF rules and private link
+- Azure Front Door profiles must use a **minimum TLS version of 1.2**
+- Web Application Firewall (WAF) on Azure Front Door must have **request body inspection** enabled
+- Web Application Firewall (WAF) must be enabled for Azure Front Door **entry-points**
+- **Bot Protection** must be enabled for Azure Front Door WAF
+- Web Application Firewall (WAF) **rate limit rule** for Azure Front Door must be enabled
+- Secure **private connectivity** between Azure Front Door Premium and Azure Storage Blob, or Azure App Service must be configured
+- Web Application Firewall (WAF) must use the specified **mode** (ie. **Prevention**) for Azure Front Door Service
 
 ## Deployment failures due to policy violation
 

--- a/docs/azure/azure-services/front-door.md
+++ b/docs/azure/azure-services/front-door.md
@@ -6,16 +6,16 @@ Azure Front Door is a global entry point that uses the Microsoft edge network to
 
 ## Security requirements
 
-The following security settings are **required** in Landing Zones.
+The following security settings are **required** in Landing Zones:
 
-- Azure Front Door profiles must use the **Premium tier** that supports managed WAF rules and private link
+- Azure Front Door profiles must use the **Premium tier** that supports managed Web Application Firewall (WAF) rules and private link
 - Azure Front Door profiles must use a **minimum TLS version of 1.2**
-- Web Application Firewall (WAF) on Azure Front Door must have **request body inspection** enabled
-- Web Application Firewall (WAF) must be enabled for Azure Front Door **entry-points**
+- WAF on Azure Front Door must have **request body inspection** enabled
+- WAF must be enabled for Azure Front Door **entry-points**
 - **Bot Protection** must be enabled for Azure Front Door WAF
-- Web Application Firewall (WAF) **rate limit rule** for Azure Front Door must be enabled
-- Secure **private connectivity** between Azure Front Door Premium and Azure Storage Blob, or Azure App Service must be configured
-- Web Application Firewall (WAF) must use the specified **mode** (ie. **Prevention**) for Azure Front Door Service
+- WAF **rate limit rule** for Azure Front Door must be enabled
+- Secure **private connectivity** between Azure Front Door Premium and Azure Storage Blob or Azure App Service must be configured
+- WAF must use the specified **mode** (i.e. **Prevention**) for Azure Front Door Service
 
 ## Deployment failures due to policy violation
 


### PR DESCRIPTION
This pull request adds detailed security requirements sections to the documentation for both Azure Application Gateway and Azure Front Door. These sections specify the mandatory security configurations that must be enforced in Landing Zones to comply with best practices and organizational policies.

**Security requirements documentation:**

*Azure Front Door:*
- Added a new "Security requirements" section listing required settings, such as using the Premium tier, enabling WAF with request body inspection, enforcing minimum TLS 1.2, enabling bot protection and rate limiting, requiring private connectivity, and specifying WAF mode.

*Azure Application Gateway:*
- Added a new "Security requirements" section outlining necessary configurations, including at least one security policy, enabling WAF with request body inspection, and enabling bot protection in all WAF policies.